### PR TITLE
Modulizr fix for master

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -835,7 +835,7 @@
 	} else if (typeof module !== 'undefined' && module.exports) {
 		module.exports = FastClick.attach;
 		module.exports.FastClick = FastClick;
-	} else {
-		window.FastClick = FastClick;
 	}
+	
+	window.FastClick = FastClick;
 }());

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -836,6 +836,7 @@
 		module.exports = FastClick.attach;
 		module.exports.FastClick = FastClick;
 	}
-	
+
 	window.FastClick = FastClick;
+	
 }());


### PR DESCRIPTION
This is to fix Fastclick on pages where uitk is not using Modulizr yet, but the page uses it for other parts. In that case, Fastclick has to be available for core, but it also needs to be defined as a module (with an ID)
